### PR TITLE
[Feature] re-arrange frus volumes elements 

### DIFF
--- a/app/scss/_all-volumes.scss
+++ b/app/scss/_all-volumes.scss
@@ -31,8 +31,15 @@
       }
     }
 
+    dl {
+      grid-template-columns: auto auto;
+      display: grid;
+      justify-content: start;
+      grid-column-gap: 1rem;
+    }
+
     dt {
-      display: none;
+      display: inline;
     }
 
     dd {

--- a/pages/historicaldocuments/volume-titles.xml
+++ b/pages/historicaldocuments/volume-titles.xml
@@ -21,37 +21,39 @@
                     <li class="hsg-list__item" data-template="templates:each" data-template-from="volumes-meta" data-template-to="volume-meta">
                         <div class="hsg-list__item__row--alignstart">
                             <img class="hsg-list__thumbnail" data-template="fm:thumbnail"/>
-                            <h3 class="hsg-list__title">
-                                <a class="hsg-list__link" data-template="fm:title-link"><span data-template="fm:title"/></a>
-                            </h3>
-                            <dl>
-                                <dt data-template="fm:if-pub-date">Published</dt>
-                                <dd data-template="fm:if-pub-date"><time data-template="fm:pub-date"/></dd>
-                                
-                                <dt data-template="fm:if-not-pub-date">Publication Status:</dt>
-                                <dd data-template="fm:pub-status"/>
-                                
-                                <dt data-template="fm:isbn-format"/>
-                                <dd data-template="fm:isbn"/>
-                            </dl>
-                            <div data-template="fm:get-media-types">
-                                <ul class="hsg-list__media__download" data-template="fm:if-media">
-                                    <li data-template="fm:if-media-type" data-template-type="mobi">
-                                        <button class="hsg-link-button--outline">Mobi
-                                                <span>12mb</span></button>
-                                    </li>
-                                    <li data-template="fm:if-media-type" data-template-type="epub">
-                                        <button class="hsg-link-button--outline">epub
-                                                2<span>123kb</span></button>
-                                    </li>
-                                    <!--<li data-template="fm:if-media-type" data-template-type="epub3">
-                                    <button class="hsg-link-button-\-outline">Epub 3<span>123mb</span></button>
-                                </li>-->
-                                    <li data-template="fm:if-media-type" data-template-type="pdf">
-                                        <button class="hsg-link-button--outline">PDF
-                                                <span>123mb</span></button>
-                                    </li>
-                                </ul>
+                            <div>
+                                <h3 class="hsg-list__title">
+                                    <a class="hsg-list__link" data-template="fm:title-link"><span data-template="fm:title"/></a>
+                                </h3>
+                                <dl>
+                                    <dt data-template="fm:if-pub-date">Published</dt>
+                                    <dd data-template="fm:if-pub-date"><time data-template="fm:pub-date"/></dd>
+                                    
+                                    <dt data-template="fm:if-not-pub-date">Publication Status:</dt>
+                                    <dd data-template="fm:pub-status"/>
+                                    
+                                    <dt data-template="fm:isbn-format"/>
+                                    <dd data-template="fm:isbn"/>
+                                </dl>
+                                <div data-template="fm:get-media-types">
+                                    <ul class="hsg-list__media__download" data-template="fm:if-media">
+                                        <li data-template="fm:if-media-type" data-template-type="mobi">
+                                            <button class="hsg-link-button--outline">Mobi
+                                                    <span>12mb</span></button>
+                                        </li>
+                                        <li data-template="fm:if-media-type" data-template-type="epub">
+                                            <button class="hsg-link-button--outline">epub
+                                                    2<span>123kb</span></button>
+                                        </li>
+                                        <!--<li data-template="fm:if-media-type" data-template-type="epub3">
+                                        <button class="hsg-link-button-\-outline">Epub 3<span>123mb</span></button>
+                                    </li>-->
+                                        <li data-template="fm:if-media-type" data-template-type="pdf">
+                                            <button class="hsg-link-button--outline">PDF
+                                                    <span>123mb</span></button>
+                                        </li>
+                                    </ul>
+                                </div>
                             </div>
                         </div>
                     </li>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30597211/194132336-60bb523b-00b1-4bf4-a44f-68977463d248.png)
this makes the `published` item and `ISBN`  arranged as the image shows