### PR TITLE
[fix] page should not be reloaded after navigation

### DIFF
--- a/resources/scripts/app.js
+++ b/resources/scripts/app.js
@@ -1,53 +1,56 @@
+function initializeImageViewer() {
+    if ($("#viewer").get(0) != undefined) {
+        console.log('Image URI=', scheme + '://' + server + ':' + port + '/iiif/3/' + documentId + '%2Ftiff%2F' + facsId + '.tif');
+
+        var osd_viewer = $('.osd-wrapper #viewer'),
+            documentId = osd_viewer.attr('data-doc-id'),
+            facsId = osd_viewer.attr('data-facs'),
+            scheme = 'http',
+            server = 'localhost', // Local Cantaloupe image server for development
+            port = '8182',
+            debugMode = false;
+
+        var viewer = OpenSeadragon({
+            id: "viewer",
+            prefixUrl: "resources/images/OSD-icons/",
+            preserveViewport: true,
+            visibilityRatio: 1,
+            //minZoomLevel:         1,
+            minZoomImageRatio: 0.9,
+            defaultZoomLevel: 1,
+            sequenceMode: true,
+            showNavigator: true,
+            navigatorHeight: "120px",
+            navigatorWidth: "80px",
+            showSequenceControl: false,
+            debugMode: debugMode,
+            tileSources: [{
+                "@context": "http://iiif.io/api/image/3/context.json",
+                "@id": scheme + "://" + server + ':' + port + "/iiif/3/" + documentId + "%2Ftiff%2F" + facsId + ".tif",
+                "height": 5069,
+                "width": 3040,
+                "maxArea": 10000000,
+                "profile": ["http://iiif.io/api/image/2/level2.json"],
+                "protocol": "http://iiif.io/api/image",
+                "tiles": [{
+                    "scaleFactors": [1, 2, 4, 8, 16, 32],
+                    "width": 512,
+                    "height": 512
+                }]
+            }]
+        });
+    }
+}
+
 $(document).ready(function($) {
     var historySupport = !!(window.history && window.history.pushState);
     var appRoot = $("html").attr("data-app");
-
-    var osd_viewer = $('.osd-wrapper #viewer'),
-        documentId = osd_viewer.attr('data-doc-id'),
-        facsId     = osd_viewer.attr('data-facs'),
-        scheme     = 'http',
-        server     = 'localhost', // Local Cantaloupe image server for development
-        port       = '8182',
-        debugMode  = false;
-
 
     // http://openseadragon.github.io/docs/OpenSeadragon.html#.Options
     var isConnected = $( "#viewer" ).get(0);
     //if ( $( "#viewer" ).get(0) === undefined ) { console.log('No viewer') };
 
-    if ($("#viewer").get(0) != undefined) {
-      console.log('Image URI=', scheme + '://' + server + ':' + port + '/iiif/3/' + documentId + '%2Ftiff%2F' + facsId + '.tif')
-
-      var viewer = OpenSeadragon({
-          id:                   "viewer",
-          prefixUrl:            "resources/images/OSD-icons/",
-          preserveViewport:     true,
-          visibilityRatio:      1,
-          //minZoomLevel:         1,
-          minZoomImageRatio:    0.9,
-          defaultZoomLevel:     1,
-          sequenceMode:         true,
-          showNavigator:        true,
-          navigatorHeight:      "120px",
-          navigatorWidth:       "80px",
-          showSequenceControl:  false,
-          debugMode:            debugMode,
-          tileSources:   [{
-            "@context": "http://iiif.io/api/image/3/context.json",
-            "@id":      scheme + "://" + server + ':' + port + "/iiif/3/" + documentId + "%2Ftiff%2F" + facsId + ".tif",
-            "height":   5069,
-            "width":    3040,
-            "maxArea":  10000000,
-            "profile":  [ "http://iiif.io/api/image/2/level2.json" ],
-            "protocol": "http://iiif.io/api/image",
-            "tiles": [{
-              "scaleFactors": [ 1, 2, 4, 8, 16, 32 ],
-              "width":        512,
-              "height":       512
-            }]
-          }]
-      });
-    }
+    initializeImageViewer();
 
     // https://github.com/uxitten/polyfill/blob/master/string.polyfill.js
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart
@@ -102,7 +105,7 @@ $(document).ready(function($) {
                     // Check if an image viewer is requested,
                     // needs a reload to request & initialize Openseadragon!
                     if (data.viewer) {
-                      location.reload();
+                        initializeImageViewer();
                     }
                     initContent();
                     if (data.title) {
@@ -112,8 +115,10 @@ $(document).ready(function($) {
                         $("html head title").text(data.windowTitle);
                     }
                     if (data.breadcrumbSection) {
-                        $(".breadcrumb .section-breadcrumb").remove();
-                        $(".breadcrumb").append(data.breadcrumbSection);
+                        var oldBreadcrumb = $(".hsg-breadcrumb ol li:last-child");
+                        var newBreadcrumb = $(data.breadcrumbSection);
+                        $('a', oldBreadcrumb).attr('href', $('a', oldBreadcrumb).attr('href').replace(/\/[^\/]+$/, '/' + $('a', newBreadcrumb).attr('href')));
+                        $('a span', oldBreadcrumb).text($('a', newBreadcrumb).text());
                         // $(".breadcrumb .section").html(data.breadcrumbSection);
                     }
                     if (data.persons) {


### PR DESCRIPTION
I moved the image viewer initialization code to a global function that is called when the page load, as well as after navigation, eliminating the need to reload the page.

Also, I fixed the code that updates breadcrumbs after navigation here:

https://github.com/evolvedbinary/hsg-shell/blob/e5495a72614fc16b38e801ea3f887a9bb5d35d48/resources/scripts/app.js#L118-L121

By replaceing the text and the `href` for the link with the new data.
However, I think it would be better to fix it on the server, so we can simply swap the old `li` with the new one, most likely here:

https://github.com/evolvedbinary/hsg-shell/blob/e5495a72614fc16b38e801ea3f887a9bb5d35d48/modules/frus-ajax.xql#L139

I am not sure how this is supposed to work, but it would make sense if `fh:section-breadcrumb` used here should be (or at least outputs) the same html used when generating the code